### PR TITLE
🐛 fix segfault on number of team parsing

### DIFF
--- a/zappy_ai_src/Connection/ServerAI.cpp
+++ b/zappy_ai_src/Connection/ServerAI.cpp
@@ -20,7 +20,6 @@ void AI::ServerAI::handleCommand() {
     while (buffer.find("\n") != std::string::npos) {
         size_t pos = buffer.find("\n");
         std::string command = buffer.substr(0, pos);
-        std::cout << "Received command: " << command << std::endl;
         buffer.erase(0, pos + 1);
 
         if (command.empty()) continue;

--- a/zappy_ai_src/Connection/ServerAI.cpp
+++ b/zappy_ai_src/Connection/ServerAI.cpp
@@ -20,6 +20,7 @@ void AI::ServerAI::handleCommand() {
     while (buffer.find("\n") != std::string::npos) {
         size_t pos = buffer.find("\n");
         std::string command = buffer.substr(0, pos);
+        std::cout << "Received command: " << command << std::endl;
         buffer.erase(0, pos + 1);
 
         if (command.empty()) continue;

--- a/zappy_server_src/include/parser.h
+++ b/zappy_server_src/include/parser.h
@@ -15,6 +15,7 @@ typedef struct parser_s {
     char **team_names;
     int clients_per_team;
     int freq;
+    int nb_teams;
 } parser_t;
 
 typedef struct parser_str_s {

--- a/zappy_server_src/include/zappy.h
+++ b/zappy_server_src/include/zappy.h
@@ -64,7 +64,7 @@ void incr_mendiane(cell_t *cell);
 void incr_phiras(cell_t *cell);
 void incr_thystame(cell_t *cell);
 
-starting_map_t *init_starting_map(zappy_t *zappy, int num_teams);
+starting_map_t *init_starting_map(zappy_t *zappy);
 void free_starting_map(starting_map_t *map, int height);
 
 void start_server(zappy_t *zappy);

--- a/zappy_server_src/main.c
+++ b/zappy_server_src/main.c
@@ -10,6 +10,7 @@
 #include <signal.h>
 #include <string.h>
 #include <time.h>
+#include <sys/types.h>
 
 
 #include "include/zappy.h"
@@ -62,7 +63,7 @@ int main(int ac, char **av)
     }
     zappy_ptr->server = create_server(zappy_ptr->parser->port);
     zappy_ptr->clients = NULL;
-    zappy_ptr->map = init_starting_map(zappy_ptr, 2);
+    zappy_ptr->map = init_starting_map(zappy_ptr);
     zappy_ptr->idNextClient = 0;
     setup_down_server();
     start_server(zappy_ptr);

--- a/zappy_server_src/map_creation.c
+++ b/zappy_server_src/map_creation.c
@@ -39,13 +39,13 @@ static void add_egg(starting_map_t *map, int id, const char *team_name,
     map->eggs = new_egg;
 }
 
-static void do_distrib(starting_map_t *map, zappy_t *zappy, int num_teams)
+static void do_distrib(starting_map_t *map, zappy_t *zappy)
 {
     int grid_size = zappy->parser->width * zappy->parser->height;
     int a = 0;
 
     map->eggs = NULL;
-    for (int i = 0; i < num_teams; ++i) {
+    for (int i = 0; i < zappy->parser->nb_teams; ++i) {
         for (int j = 0; j < zappy->parser->clients_per_team; ++j)
             add_egg(map, a++, zappy->parser->team_names[i], zappy);
     }
@@ -66,7 +66,7 @@ static void init_line(zappy_t *zappy, starting_map_t *map, int y)
     }
 }
 
-starting_map_t *init_starting_map(zappy_t *zappy, int num_teams)
+starting_map_t *init_starting_map(zappy_t *zappy)
 {
     starting_map_t *map = malloc(sizeof(starting_map_t));
 
@@ -85,7 +85,7 @@ starting_map_t *init_starting_map(zappy_t *zappy, int num_teams)
         }
         init_line(zappy, map, y);
     }
-    do_distrib(map, zappy, num_teams);
+    do_distrib(map, zappy);
     return (map);
 }
 

--- a/zappy_server_src/parser.c
+++ b/zappy_server_src/parser.c
@@ -77,7 +77,21 @@ static parser_t *init_parser(void)
     parser->team_names = NULL;
     parser->clients_per_team = 0;
     parser->freq = 100;
+    parser->nb_teams = 0;
     return parser;
+}
+
+static int pointlen(char **str)
+{
+    int i = 0;
+
+    i = 0;
+    if (str == NULL)
+        return (0);
+    while (str[i] != NULL) {
+        i++;
+    }
+    return (i);
 }
 
 parser_t *parse_arguments(int ac, char **av)
@@ -91,8 +105,10 @@ parser_t *parse_arguments(int ac, char **av)
             parser->width = parse_int(av[i + 1], 10, 42);
         if (strcmp(av[i], "-y") == 0 && i + 1 < ac)
             parser->height = parse_int(av[i + 1], 10, 42);
-        if (strcmp(av[i], "-n") == 0)
+        if (strcmp(av[i], "-n") == 0) {
             parser->team_names = parse_teams(av, &i, ac);
+            parser->nb_teams = pointlen(parser->team_names);
+        }
         if (strcmp(av[i], "-c") == 0 && i + 1 < ac)
             parser->clients_per_team = parse_int(av[i + 1], 1, 200);
         if (strcmp(av[i], "-f") == 0 && i + 1 < ac)


### PR DESCRIPTION
## Description

This PR fixes the parsing of the team number, which wasn't present before, as well as hardcoded in the main, it has now been added to the parsing data structure, along the team names.

## Related Tickets & Documents

None

Closed Issues : None, this is a quickfix
