### PR TITLE
:sparkles: add the libc folder + appropriate compilation

### DIFF
--- a/libc/include/pointlen.h
+++ b/libc/include/pointlen.h
@@ -1,0 +1,19 @@
+/*
+** EPITECH PROJECT, 2023
+** pointlen.h
+** File description:
+** Header for pointlen function
+*/
+
+#ifndef POINTLEN_H_
+#define POINTLEN_H_
+
+/**
+ * @brief Count the number of elements in a NULL-terminated array of pointers
+ * 
+ * @param str NULL-terminated array of pointers
+ * @return int number of elements in the array
+ */
+int pointlen(char **str);
+
+#endif /* POINTLEN_H_ */

--- a/libc/pointlen.c
+++ b/libc/pointlen.c
@@ -1,0 +1,22 @@
+/*
+** EPITECH PROJECT, 2023
+** get function
+** File description:
+** contain most function that search for things
+*/
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int pointlen(char **str)
+{
+    int i = 0;
+
+    i = 0;
+    if (str == NULL)
+        return (0);
+    while (str[i] != NULL) {
+        i++;
+    }
+    return (i);
+}

--- a/zappy_server_src/parser.c
+++ b/zappy_server_src/parser.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 
 #include "include/parser.h"
+#include "pointlen.h"
 
 void display_help(void)
 {
@@ -79,19 +80,6 @@ static parser_t *init_parser(void)
     parser->freq = 100;
     parser->nb_teams = 0;
     return parser;
-}
-
-static int pointlen(char **str)
-{
-    int i = 0;
-
-    i = 0;
-    if (str == NULL)
-        return (0);
-    while (str[i] != NULL) {
-        i++;
-    }
-    return (i);
 }
 
 parser_t *parse_arguments(int ac, char **av)


### PR DESCRIPTION
## Description

This PR adds the `libc` folder for all C code, similar to the `lib` folder, used for old code.

## Related Tickets & Documents

Closed Issues : #117 
