### PR TITLE
♻️  separate players gui clients commands pools

### DIFF
--- a/zappy_server_src/command_parsing/commands_name_size_lists.c
+++ b/zappy_server_src/command_parsing/commands_name_size_lists.c
@@ -16,6 +16,7 @@ const command_name_size_t command_name_size_list[] = {
     {"LOOK", 7},
     {"INVENTORY", 1},
     {"BROADCAST", 7},
+    {"CONNECT_NBR", 0},
     {"FORK", 42},
     {"EJECT", 7},
     {"TAKE", 7},

--- a/zappy_server_src/command_parsing/commands_name_size_lists.c
+++ b/zappy_server_src/command_parsing/commands_name_size_lists.c
@@ -9,7 +9,7 @@
 
 #include "command.h"
 
-const command_name_size_t command_name_size_list[] = {
+const command_name_size_t player_command_name_size_list[] = {
     {"FORWARD", 7},
     {"RIGHT", 7},
     {"LEFT", 7},
@@ -23,4 +23,13 @@ const command_name_size_t command_name_size_list[] = {
     {"SET", 7},
     {"INCANTATION", 300},
     {NULL, -1}
+};
+
+const command_name_size_t gui_command_name_size_list[] = {
+    {"MSZ", 0},
+    {"BCT", 0},
+    {"MCT", 0},
+    {"TNA", 0},
+    {"SGT", 0},
+    {"SST", 0}
 };

--- a/zappy_server_src/command_parsing/get_command_duration.c
+++ b/zappy_server_src/command_parsing/get_command_duration.c
@@ -10,10 +10,18 @@
 
 #include "command.h"
 
-int get_command_duration(const char *name)
+int get_gui_command_duration(const char *name)
 {
-    for (int i = 0; command_name_size_list[i].name != NULL; i++)
-        if (strcmp(command_name_size_list[i].name, name) == 0)
-            return command_name_size_list[i].duration;
+    for (int i = 0; gui_command_name_size_list[i].name != NULL; i++)
+        if (strcmp(gui_command_name_size_list[i].name, name) == 0)
+            return gui_command_name_size_list[i].duration;
+    return -1;
+}
+
+int get_player_command_duration(const char *name)
+{
+    for (int i = 0; player_command_name_size_list[i].name != NULL; i++)
+        if (strcmp(player_command_name_size_list[i].name, name) == 0)
+            return player_command_name_size_list[i].duration;
     return -1;
 }

--- a/zappy_server_src/command_parsing/push_command_to_queue.c
+++ b/zappy_server_src/command_parsing/push_command_to_queue.c
@@ -70,7 +70,10 @@ void push_command_to_queue(char **args, client_t *client, zappy_t *zappy_ptr)
     if (get_size_commands(client->waiting_commands) >= 10)
         return;
     set_upper(args);
-    command_duration = get_command_duration(args[0]);
+    if (strcmp(client->team_name, "GRAPHICAL") == 0)
+        command_duration = get_gui_command_duration(args[0]);
+    else
+        command_duration = get_player_command_duration(args[0]);
     if (command_duration != -1) {
         LOG_INFO("[%i]: Received %s", client->fd, args[0]);
         if (!add_command(7, args, client))

--- a/zappy_server_src/include/command.h
+++ b/zappy_server_src/include/command.h
@@ -16,9 +16,11 @@ typedef struct command_name_size_s {
     unsigned int duration; 
 } command_name_size_t;
 
-extern const command_name_size_t command_name_size_list[];
+extern const command_name_size_t player_command_name_size_list[];
+extern const command_name_size_t gui_command_name_size_list[];
 
-int get_command_duration(const char *name);
+int get_gui_command_duration(const char *name);
+int get_player_command_duration(const char *name);
 
 void handle_client_command(zappy_t *zappy, int fd);
 void send_client_command(zappy_t *zappy, int fd);


### PR DESCRIPTION
## Description

Split the old `command_name_size_list` into `player_command_name_size_list` & `gui_command_name_size_list`.

This allows us to filter the commands and their permissions before putting them in the client's queues.
Then, the consumer of these commands doesn't needs to worry if a client can use this command or not !

## Related Tickets & Documents

Closed Issues :
