### PR TITLE
:sparkles: Send disconnection message to graphics when a client disconnect

### DIFF
--- a/zappy_server_src/command.c
+++ b/zappy_server_src/command.c
@@ -65,6 +65,7 @@ static bool get_client_buffer(client_t *client, int fd, zappy_t *zappy)
 void handle_client_command(zappy_t *zappy, int fd)
 {
     client_t *current = zappy->clients;
+    char buffer[1024];
 
     while (current != NULL && current->fd != fd) {
         current = current->next;
@@ -72,7 +73,9 @@ void handle_client_command(zappy_t *zappy, int fd)
     if (current == NULL)
         return;
     if (get_client_buffer(current, fd, zappy) == false) {
+        sprintf(buffer, "pdi %d\n", current->stats.id);
         LOG_INFO("Client with fd %d disconnected", fd);
+        send_data_to_graphics(zappy, buffer);
         remove_client(zappy, fd);
     }
 }


### PR DESCRIPTION
## Description

This PR adds a send message to the graphics when a player disconnect to kill the player

## Related Tickets & Documents

Closed Issues : #193 
