### PR TITLE
🐛 Prevent infinite reconnection loop when GUI is not running

### DIFF
--- a/zappy_gui_src/Connection/connectionWithServer.cpp
+++ b/zappy_gui_src/Connection/connectionWithServer.cpp
@@ -31,7 +31,7 @@ int loopClient(int sockfd) {
         LOG_WARNING("Server closed");
         close(sockfd);
         bool reconnected = false;
-        while (!reconnected) {
+        while (!reconnected && GUI::DataManager::i().running) {
             try {
                 reconnected = (client_connection(sockfd) != 84);
             } catch (const GUI::InvalidDataException &e) {


### PR DESCRIPTION
## Description

This PR fix the gui not cosing when no server was runing
