### PR TITLE
🐛 Fix player info drawing condition to handle empty player list

### DIFF
--- a/zappy_gui_plugins_src/PlayerDataPlugin.cpp
+++ b/zappy_gui_plugins_src/PlayerDataPlugin.cpp
@@ -22,9 +22,8 @@ pluginsData::Tile PlayerDataPlugin::getTile(int x, int y) {
 
 void PlayerDataPlugin::drawPlayerInfo(int id,
 std::shared_ptr<irr::gui::IGUIFont> font) {
-    if (!font || id < 0 || id >= static_cast<int>(data.players.size()))
+    if (!font || id < 0 || data.players.size() == 0)
         return;
-    printf("Drawing player info for player %d\n", id);
 
     int width = driver->getScreenSize().Width;
     pluginsData::Player player = data.getPlayer(id);


### PR DESCRIPTION
## Description

This PR fix the drawing of the data of a player with the pluginDataPlayer

## Related Tickets & Documents

Closed Issues : #291 
