### PR TITLE
📝 Add -o to the -h & readme for the gui

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ USAGE: ./zappy_gui -p port -h machine
 | -p | port | port number |
 | -h | machine | hostname of the server |
 | -v, -vv, -vvv | ---- | set verbose level (WARNINGS, INFOS, DEBUGS) |
+| -o | Enable low detail mode |
 
 </details>
 

--- a/zappy_gui_src/main.cpp
+++ b/zappy_gui_src/main.cpp
@@ -57,7 +57,8 @@ int returnHelp() {
               << "Options:\n"
               << "  -h <ip>       : Set the server IP address\n"
               << "  -p <port>     : Set the server port (0-65535)\n"
-              << "  -v, -vv, -vvv : Set verbose level (WARNING, INFO, DEBUG\n";
+              << "  -v, -vv, -vvv : Set verbose level (WARNING, INFO, DEBUG\n"
+              << "  -o            : Enable low detail mode\n";
     return 84;
 }
 


### PR DESCRIPTION
## Description

Add missing -o flag for optimisation in the GUI (in --help & readme)
## Related Tickets & Documents

Closed Issues : None
